### PR TITLE
Fix LineEndings stream filter corrupting UTF-8 byte 0x85

### DIFF
--- a/tachyon/v/0.0.0/app/libraries/MailSo/Base/StreamFilters/LineEndings.php
+++ b/tachyon/v/0.0.0/app/libraries/MailSo/Base/StreamFilters/LineEndings.php
@@ -9,8 +9,8 @@ class LineEndings extends \php_user_filter
 	public function filter($in, $out, &$consumed, $closing)
 	{
 		while ($bucket = \stream_bucket_make_writeable($in)) {
-			$bucket->data = \preg_replace('/\R/s', "\r\n", \rtrim($bucket->data, "\r"));
-//			$bucket->data = \preg_replace('/\R/s', "\n", \rtrim($bucket->data, "\r"));
+			$bucket->data = \preg_replace('/\r\n|\r|\n/', "\r\n", \rtrim($bucket->data, "\r"));
+//			$bucket->data = \preg_replace('/\r\n|\r|\n/', "\n", \rtrim($bucket->data, "\r"));
 			$consumed += $bucket->datalen;
 			\stream_bucket_append($out, $bucket);
 		}


### PR DESCRIPTION
**Title:**
Fix Subject/MIME header truncation on UTF-8 multi-byte characters (e.g. Greek υ)

**Description:**
Hi,
I've fixed a bug present in SnappyMail/Tachyon when sending or saving emails with UTF-8 subjects. When encountering certain multi-byte Greek characters such as υ (U+03C5), the subject was truncated right before the character (So for the title Εκτίμηση συνεργασίας -> Εκτίμηση σ).

**Root Cause:**
In MailSo\Base\StreamFilters\LineEndings:
```$bucket->data` = \preg_replace('/\R/s', "\r\n", \rtrim($bucket->data, `"\r"));```

Because this regex runs without the /u (UTF-8) modifier, PCRE evaluates the stream in single-byte (8-bit) mode. In single-byte mode, \R matches byte 0x85 (NEL - Next Line / ISO-8859-1 control character).
Any multi-byte UTF-8 sequence where a continuation byte is 0x85 gets corrupted:
- Greek lowercase υ (U+03C5) is encoded in UTF-8 as \xCF\x85.
- PCRE matches \x85 as a line ending and replaces it with \r\n (CRLF).
- The stream becomes \xCF\r\n, splitting the Subject: header prematurely and terminating it in MIME/IMAP parsers.

**Solution:**
In LineEndings.php, replace /\R/s with /\r\n|\r|\n/:
$bucket->data = \preg_replace('/\r\n|\r|\n/', "\r\n", \rtrim($bucket->data, "\r"));
This safely normalizes ASCII line breaks (CRLF, CR, LF) without corrupting multi-byte UTF-8 payloads.