### PR TITLE
fix(config): load the additional configuration file

### DIFF
--- a/tachyon/v/0.0.0/app/libraries/Tachyon/Config/AbstractConfig.php
+++ b/tachyon/v/0.0.0/app/libraries/Tachyon/Config/AbstractConfig.php
@@ -21,7 +21,7 @@ abstract class AbstractConfig implements \ArrayAccess, \JsonSerializable
 		$sAdditionalFileName = \trim($sAdditionalFileName);
 		if ($sAdditionalFileName) {
 			$sAdditionalFileName = \APP_PRIVATE_DATA.'configs/'.$sAdditionalFileName;
-			if (\file_exists($this->sAdditionalFile)) {
+			if (\file_exists($sAdditionalFileName)) {
 				$this->sAdditionalFile = $sAdditionalFileName;
 			}
 		}


### PR DESCRIPTION
## Summary

`APP_CONFIGURATION_NAME` has never had any effect. The `AbstractConfig` constructor builds the additional file's path into a local variable, then tests the **property**, which is still the empty string its declaration gave it:

```php
private string $sAdditionalFile = '';
...
$sAdditionalFileName = APP_PRIVATE_DATA.'configs/'.$sAdditionalFileName;
if (file_exists($this->sAdditionalFile)) {   // always file_exists('')
    $this->sAdditionalFile = $sAdditionalFileName;
}
```

`file_exists('')` is always false, so the property is never assigned and the `Load()` branch that merges the file is never reached. The documented per-host configuration in `_include.php`:

```php
define('APP_CONFIGURATION_NAME', $_SERVER['HTTP_HOST'].'.ini');
```

therefore does nothing at all. The override silently does not apply, which is worse than an error because the site looks fine and simply ignores the file.

The fix tests the path that was just built.

## Test plan

- [x] `php -l` on the changed file
- [x] With `APP_CONFIGURATION_NAME` set to an existing file under `configs/`, a value in that file now overrides `application.ini`
- [x] With no such file, behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
