### PR TITLE
fix(contacts): make contact edits reach the CardDAV server

### DIFF
--- a/tachyon/v/0.0.0/app/libraries/Tachyon/Actions/Contacts.php
+++ b/tachyon/v/0.0.0/app/libraries/Tachyon/Actions/Contacts.php
@@ -298,6 +298,14 @@ trait Contacts
 						$oContact = new \Tachyon\Providers\AddressBook\Classes\Contact();
 					}
 					$oContact->setVCard($vCard);
+
+					// An edit loads the stored row, so Changed still holds the old
+					// timestamp, and setVCard leaves it alone because Sync() shares it
+					// for pulled contacts. Without a fresh stamp Sync() never sees the
+					// local copy as newer, so the edit is never uploaded and the next
+					// pull overwrites it. PdoCalendar::EventSave does the same.
+					$oContact->Changed = \time();
+
 					$bResult = $oAddressBookProvider->ContactSave($oContact);
 				}
 			}

--- a/tachyon/v/0.0.0/app/libraries/Tachyon/Providers/AddressBook/PdoAddressBook.php
+++ b/tachyon/v/0.0.0/app/libraries/Tachyon/Providers/AddressBook/PdoAddressBook.php
@@ -223,9 +223,11 @@ class PdoAddressBook
 		if ($bReadWrite) {
 			foreach ($aLocalSyncData as $sKey => $aData) {
 				if ((empty($aData['etag']) && !isset($aRemoteSyncData[$sKey])) // new
-				 // newer
+				 // newer. The etags are not compared: after a clean sync the local
+				 // etag is the one our own PUT returned, so they are equal, and a
+				 // local edit could never be uploaded. A differing etag is a
+				 // conflict signal, and timestamps decide those either way.
 				 || (!empty($aData['etag']) && isset($aRemoteSyncData[$sKey]) &&
-						$aRemoteSyncData[$sKey]['etag'] !== $aData['etag'] &&
 						$aRemoteSyncData[$sKey]['changed'] < $aData['changed']
 					)
 				) {


### PR DESCRIPTION
## Summary

Editing a contact in webmail appeared to save and then silently reverted on the next CardDAV sync. Creating a contact was fine, which was the tell. Two things were wrong, one hiding behind the other.

**1. An edit never advanced `Changed`.** `DoContactSave` loads the existing row for an edit, so `Changed` arrives holding the stored timestamp. `setVCard` does not advance it: its REV parsing is commented out, and it is shared with `Sync()`'s pull path, where stamping a local "now" would make a freshly pulled contact look locally newer and push it straight back. So the row was written back with its own old timestamp, `Sync()` never saw `remote.changed < local.changed`, and the pull branch, seeing the remote as newer, overwrote the edit. A created contact escaped this because a fresh `Contact`'s constructor stamps `time()`.

Fixed at the local-edit entry point in `Actions/Contacts.php`, which is what `PdoCalendar::EventSave` already does for events.

**2. The upload was gated on a differing etag.** With the timestamp fixed, the edit still did not upload. `Sync()` only pushed a previously synced contact when the remote etag differed from the stored one. But the stored etag is the one Tachyon's own PUT returned, so after a clean sync they are always equal and the condition could never hold. The edit stuck locally and looked correct while the server still held the old card.

A differing etag means the remote changed too. That is a conflict signal, not the definition of a local edit, so it should not gate the upload. The gate is removed and the timestamp comparison alone decides, as it already did for the pull direction.

## Effect on conflict handling

The change is strictly additive. Before, a push required a differing etag **and** an older remote. Now it requires only an older remote. The only new case is *equal etags with an older remote*, which is exactly a local edit after a clean sync. When the remote is newer, the pull loop below still takes the remote, as before.

## Test plan

- [x] `php -l` on both files
- [x] Edit an existing contact, trigger sync: the server's card now carries the edit and the local etag updates to the PUT's response
- [x] Create a contact: still uploaded on first sync
- [x] Edit a contact on the server side, trigger sync: the local copy is replaced (pull direction unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
