### PR TITLE
fix(dav): follow 302, 307 and 308 redirects as well as 301

### DIFF
--- a/tachyon/v/0.0.0/app/libraries/tachyon_util/dav/client.php
+++ b/tachyon/v/0.0.0/app/libraries/tachyon_util/dav/client.php
@@ -92,10 +92,13 @@ class Client
 			$headers['Authorization'] = $this->sPreemptiveAuth;
 		}
 		$response = $this->HTTP->doRequest($method, $url, $body, $headers);
-		if (301 == $response->status) {
-			// Like: RewriteRule ^\.well-known/carddav /nextcloud/remote.php/dav [R=301,L]
+		// Like: RewriteRule ^\.well-known/carddav /nextcloud/remote.php/dav [R=301,L]
+		// Apache answers 302 without R=301, and Stalwart answers the well-known
+		// paths with 307. All four keep the method and body, which a PROPFIND
+		// needs. 303 means "GET this instead", so it is not followed.
+		if (\in_array($response->status, array(301, 302, 307, 308), true)) {
 			$location = $response->getRedirectLocation();
-			\Tachyon\Util\Log::info('DAV', "301 Redirect {$url} to {$location}");
+			\Tachyon\Util\Log::info('DAV', "{$response->status} Redirect {$url} to {$location}");
 			$url = \preg_replace('@^(https?:)?//[^/]+[/$]@', '/', $location);
 			$parts = \parse_url($this->baseUri);
 			$url = $parts['scheme'] . '://' . $parts['host'] . (isset($parts['port'])?':' . $parts['port']:'') . $url;


### PR DESCRIPTION
## Summary

Discovery probes `/.well-known/carddav` and `/.well-known/caldav` before the supplied path, and the DAV client followed only a **301** from there. Two common servers answer differently:

- Apache's `RewriteRule` answers **302** unless `R=301` is given.
- Stalwart answers the well-known paths with **307**.

Against either, the probe raised an exception and discovery fell back to the supplied path. That worked when the operator had supplied a full path and failed when they had supplied only the host, which is exactly the case the well-known probe exists for.

The client now follows 301, 302, 307 and 308. All four keep the method and body on the second request, which a PROPFIND needs. **303** means "GET this instead" and is still not followed. The existing same-host rule is unchanged: the Location's path is taken and the host comes from the configured base URI. Still a single hop, as before.

## Test plan

Verified with a local `php -S` server answering each code on `/redir/<code>` with a Location to `/dav/`, which answers 207 and echoes the request method:

```
PASS  301: expected follow, followed, 207, method preserved: yes
PASS  302: expected follow, followed, 207, method preserved: yes
PASS  307: expected follow, followed, 207, method preserved: yes
PASS  308: expected follow, followed, 207, method preserved: yes
PASS  303: expected raise, raised 303
```

The same probe against the unchanged client fails 302, 307 and 308.

- [x] `php -l` on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
