### PR TITLE
fix(logs): the stderr driver reaches a log under php-fpm

### DIFF
--- a/plugins/example/index.php
+++ b/plugins/example/index.php
@@ -456,6 +456,6 @@ class ExamplePlugin extends \Tachyon\Plugins\AbstractPlugin
 	$this->Manager()->IsEnabled() : bool
 	$this->Manager()->Count() : int
 	$this->Manager()->WriteLog(string $sDesc, int $iType = \LOG_INFO) : void
-	$this->Manager()->WriteException(string $sDesc, int $iType = \LOG_INFO) : void
+	$this->Manager()->WriteException(\Throwable $oException, int $iType = \LOG_NOTICE) : void
 */
 }

--- a/tachyon/v/0.0.0/app/libraries/MailSo/Log/Drivers/StderrStream.php
+++ b/tachyon/v/0.0.0/app/libraries/MailSo/Log/Drivers/StderrStream.php
@@ -18,16 +18,58 @@ namespace MailSo\Log\Drivers;
  */
 class StderrStream extends \MailSo\Log\Driver
 {
+	/** @var resource */
+	private $rStream;
+
+	/**
+	 * Whether fd 2 leads anywhere. A php-fpm worker inherits /dev/null on it
+	 * unless the pool sets catch_workers_output, so a raw write there vanishes
+	 * while every config key says logging is on. Decided once: the target
+	 * cannot change during a request and the check costs two stat calls.
+	 */
+	private bool $bStreamIsSink;
+
+	/**
+	 * @param resource|null $rStream Defaults to STDERR; injectable for tests.
+	 */
+	function __construct($rStream = null)
+	{
+		parent::__construct();
+		if (null === $rStream) {
+			if (!\defined('STDERR')) {
+				\define('STDERR', \fopen('php://stderr', 'wb'));
+			}
+			$rStream = STDERR;
+		}
+		$this->rStream = $rStream;
+		$this->bStreamIsSink = static::isDevNull($rStream);
+	}
+
 	protected function writeImplementation($mDesc) : bool
 	{
-		if (!\defined('STDERR')) {
-			\define('STDERR', \fopen('php://stderr', 'wb'));
+		if ($this->bStreamIsSink) {
+			// Through the SAPI instead. Under FastCGI that is the stderr
+			// stream the web server copies into its own error log, so the
+			// line ends up where the operator who chose "stderr" will look.
+			return \error_log($mDesc);
 		}
-		return 0 < \fwrite(STDERR, $mDesc . "\n");
+		return 0 < \fwrite($this->rStream, $mDesc . "\n");
 	}
 
 	protected function clearImplementation() : bool
 	{
 		return true;
+	}
+
+	/**
+	 * @param resource $rStream
+	 */
+	private static function isDevNull($rStream) : bool
+	{
+		$aStream = \is_resource($rStream) ? @\fstat($rStream) : false;
+		$aNull = @\stat('/dev/null');
+		return $aStream && $aNull
+			&& $aStream['dev'] === $aNull['dev']
+			&& $aStream['ino'] === $aNull['ino'];
 	}
 }

--- a/tachyon/v/0.0.0/app/libraries/Tachyon/Config/Application.php
+++ b/tachyon/v/0.0.0/app/libraries/Tachyon/Config/Application.php
@@ -419,7 +419,11 @@ Examples:
   filename = "{date:Y-m-d}/{user:domain}/{user:email}_{user:uid}.log"
   filename = "{user:email}-{date:Y-m-d}.txt"
   filename = "syslog"
-  filename = "stderr"'),
+  filename = "stderr"
+
+"stderr" is the process stderr. Under php-fpm that is /dev/null unless the pool
+sets catch_workers_output, so there the line goes through the SAPI instead and
+lands in the web server\'s error log.'),
 
 				'auth_logging' => array(false, 'Enable auth logging in a separate file (for fail2ban)'),
 				'auth_logging_filename' => array('fail2ban/auth-{date:Y-m-d}.txt'),

--- a/tachyon/v/0.0.0/app/libraries/Tachyon/Plugins/Manager.php
+++ b/tachyon/v/0.0.0/app/libraries/Tachyon/Plugins/Manager.php
@@ -544,8 +544,8 @@ class Manager
 		$this->logWrite($sDesc, $iType, 'PLUGIN');
 	}
 
-	public function WriteException(string $sDesc, int $iType = \LOG_INFO) : void
+	public function WriteException(\Throwable $oException, int $iType = \LOG_NOTICE) : void
 	{
-		$this->logException($sDesc, $iType, 'PLUGIN');
+		$this->logException($oException, $iType, 'PLUGIN');
 	}
 }

--- a/test/log-stderr-driver.php
+++ b/test/log-stderr-driver.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * The "stderr" log driver must reach a log wherever the request runs.
+ *
+ * Under php-fpm a worker inherits /dev/null on fd 2 unless the pool sets
+ * catch_workers_output, so a raw write to STDERR disappears while every
+ * config key says logging is on. This checks the driver notices that and
+ * routes through the SAPI (error_log) instead, and that a real stderr is
+ * still written to directly.
+ *
+ * Usage: php test/log-stderr-driver.php
+ */
+
+$sLib = \dirname(__DIR__) . '/tachyon/v/0.0.0/app/libraries';
+require $sLib . '/MailSo/Log/Driver.php';
+require $sLib . '/MailSo/Log/Drivers/StderrStream.php';
+
+$iFailed = 0;
+$check = function (string $sName, bool $bOk) use (&$iFailed) : void {
+	echo ($bOk ? 'ok   ' : 'FAIL ') . $sName . "\n";
+	$bOk || ++$iFailed;
+};
+
+$bare = fn(\MailSo\Log\Driver $o) => $o->DisableGuidPrefix()->DisableTimePrefix()->DisableTypedPrefix();
+
+// A usable stream is written to directly.
+$rMemory = \fopen('php://memory', 'w+b');
+$oDriver = $bare(new \MailSo\Log\Drivers\StderrStream($rMemory));
+$check('write to a live stream returns true', $oDriver->Write('direct line'));
+\rewind($rMemory);
+$check('the line lands on the stream', "direct line\n" === \stream_get_contents($rMemory));
+
+// A stream on /dev/null is a black hole, so the line goes via error_log().
+$sErrorLog = \tempnam(\sys_get_temp_dir(), 'tachyon-log-');
+$sPrevious = \ini_get('error_log');
+\ini_set('error_log', $sErrorLog);
+$rNull = \fopen('/dev/null', 'wb');
+$oDriver = $bare(new \MailSo\Log\Drivers\StderrStream($rNull));
+$check('write to /dev/null still returns true', $oDriver->Write('fallback line'));
+\ini_set('error_log', $sPrevious);
+$sLogged = (string) \file_get_contents($sErrorLog);
+\unlink($sErrorLog);
+$check('the line reaches the SAPI error log', \str_contains($sLogged, 'fallback line'));
+
+// Nothing stays in the null stream (sanity: it really was /dev/null).
+\fclose($rNull);
+
+// The default construction still works on the CLI.
+$oDriver = $bare(new \MailSo\Log\Drivers\StderrStream());
+$check('default driver constructs', $oDriver instanceof \MailSo\Log\Driver);
+
+// The real thing: a PHP whose fd 2 is /dev/null, as a php-fpm worker's is.
+if ('\\' !== \DIRECTORY_SEPARATOR) {
+	$sErrorLog = \tempnam(\sys_get_temp_dir(), 'tachyon-log-');
+	$sCode = 'require ' . \var_export($sLib . '/MailSo/Log/Driver.php', true) . ';'
+		. 'require ' . \var_export($sLib . '/MailSo/Log/Drivers/StderrStream.php', true) . ';'
+		. '(new \MailSo\Log\Drivers\StderrStream)->DisableGuidPrefix()->DisableTimePrefix()->DisableTypedPrefix()->Write("worker line");';
+	\shell_exec(\escapeshellarg(\PHP_BINARY) . ' -d error_log=' . \escapeshellarg($sErrorLog)
+		. ' -r ' . \escapeshellarg($sCode) . ' 2>/dev/null');
+	$sLogged = (string) \file_get_contents($sErrorLog);
+	\unlink($sErrorLog);
+	$check('a process with /dev/null on fd 2 still logs', \str_contains($sLogged, 'worker line'));
+}
+
+echo $iFailed ? "\n{$iFailed} failed\n" : "\nall passed\n";
+exit($iFailed ? 1 : 0);


### PR DESCRIPTION
## Summary

With `[logs] filename = "stderr"` nothing is written under php-fpm, whatever `level` is set to.

**Cause.** The `StderrStream` driver does `fwrite(STDERR, ...)`. A php-fpm worker inherits `/dev/null` on fd 2 unless the pool sets `catch_workers_output`, so every line is written to a black hole while every config key says logging is on. PHP's own notices still reach the web server's error log, because `error_log()` goes through the SAPI's FastCGI stderr stream rather than the process fd, which makes the app logger look disabled.

**Fix.** The driver checks once whether its stream is `/dev/null` (by inode) and, if so, writes through `error_log()`. Under FastCGI that lands in the web server's error log. On the CLI, and in the Docker image where `catch_workers_output = yes`, it stays a raw stderr write, so nothing changes there. The `filename` config comment documents this.

**Also.** `Plugins\Manager::WriteException()` took a `string` and forwarded it to `logException()`, which requires a `\Throwable`, so any plugin calling it would hit a TypeError. It now takes the Throwable, and the example plugin's method list is updated to match.

## Test

`php test/log-stderr-driver.php` covers a live stream, a `/dev/null` stream, and a real child PHP whose fd 2 is `/dev/null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)